### PR TITLE
fix: integ regions default values

### DIFF
--- a/src/projects/cdk-construct.ts
+++ b/src/projects/cdk-construct.ts
@@ -38,7 +38,7 @@ export class MvcCdkConstructLibrary extends AwsCdkConstructLibrary {
 
   constructor(options: MvcCdkConstructLibraryOptions) {
     const baseAssetsDirectory = options.baseAssetsDirectory ?? `${cwd()}/node_modules/@mavogel/mvc-projen/assets`;
-    const integTestRegions = options.integTestRegions ?? ['eu-west-1', 'eu-west-2']
+    const integTestRegions = options.integTestRegions ?? ['eu-west-1', 'eu-west-2'];
 
     super({
       authorOrganization: true,

--- a/src/projects/cdk-construct.ts
+++ b/src/projects/cdk-construct.ts
@@ -37,7 +37,8 @@ export interface MvcCdkConstructLibraryOptions extends AwsCdkConstructLibraryOpt
 export class MvcCdkConstructLibrary extends AwsCdkConstructLibrary {
 
   constructor(options: MvcCdkConstructLibraryOptions) {
-    const baseAssetsDirectory = options.baseAssetsDirectory ?? `${cwd()}/node_modules/mvc-projen/assets`;
+    const baseAssetsDirectory = options.baseAssetsDirectory ?? `${cwd()}/node_modules/@mavogel/mvc-projen/assets`;
+    const integTestRegions = options.integTestRegions ?? ['eu-west-1', 'eu-west-2']
 
     super({
       authorOrganization: true,
@@ -282,7 +283,7 @@ add tools or links which inspired you
 
     this.package.setScript(
       'integ-test',
-      `integ-runner --directory ./integ-tests ${options.integTestRegions?.map(region => `--parallel-regions ${region}`).join(' ')} --update-on-failed,`,
+      `integ-runner --directory ./integ-tests ${integTestRegions?.map(region => `--parallel-regions ${region}`).join(' ')} --update-on-failed,`,
     );
 
     new TextFile(this, '.github/ISSUE_TEMPLATE/bug_report.md', {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, documentation, performance ...)**
set integ regions defaults as said in the  spec

**What is the current behaviour? (You can also link to an open issue here)**
no defaults for integ regions

**What is the new behaviour (if this is a feature change)?**
integ regions were empty due to no defaults

**Does this PR introduce a breaking change? (What changes might users need to make in their setup due to this PR?)**
no

**Environment**
- `node --version`: 20
- `npx projen --version`: 0.91.8
- version of the jsii lib: `0.01`
  